### PR TITLE
Add dendrogram and admixture analyses with interactive plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ mapping, and genomic prediction models suitable for research-scale studies.
 - **Flexible data ingestion** for genotype dosage matrices and phenotype traits.
 - **Quality control metrics** including call rate, minor allele frequency, heterozygosity, and
   Hardy–Weinberg equilibrium testing with configurable thresholds.
-- **Population structure characterisation** using PCA with optional scaling.
+- **Population structure characterisation** using PCA with optional scaling and dendrogram
+  clustering.
 - **Genome-wide association analysis** via ordinary least squares regression supporting
-  covariates, missing-data handling, and per-marker statistics.
+  covariates, missing-data handling, per-marker statistics, and interactive Manhattan plots.
 - **Genomic BLUP predictions** with ridge regularisation, reusable marker effects, and
   cross-validation diagnostics.
+- **Admixture estimation** using a lightweight NMF solver with stacked-bar visualisations.
 - **Command line interface** for reproducible pipelines (QC, PCA, GWAS, GBLUP).
 
 ## Installation
@@ -52,7 +54,8 @@ breeder pca \
   --geno-index id \
   --components 5 \
   --output pcs.csv \
-  --variance-out pca_variance.csv
+  --variance-out pca_variance.csv \
+  --plot-html pca_plot.html
 ```
 
 ### Genome-wide association study
@@ -66,7 +69,30 @@ breeder gwas \
   --pheno-index id \
   --covariates path/to/covariates.csv \
   --cov-index id \
-  --output gwas_results.csv
+  --output gwas_results.csv \
+  --plot-html gwas_plot.html
+```
+
+### Dendrogram clustering
+
+```bash
+breeder dendrogram \
+  --genotype path/to/genotypes.csv \
+  --geno-index id \
+  --output dendrogram_merges.csv \
+  --plot-html dendrogram.html
+```
+
+### Admixture analysis
+
+```bash
+breeder admixture \
+  --genotype path/to/genotypes.csv \
+  --geno-index id \
+  --populations 3 \
+  --output admixture_q.csv \
+  --allele-out admixture_p.csv \
+  --plot-html admixture.html
 ```
 
 ### Genomic BLUP

--- a/breeder/analysis.py
+++ b/breeder/analysis.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import math
+import random
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from .data import GenotypeDataset, PhenotypeDataset
 from .utils import (
     covariance_matrix,
     matrix_inverse,
+    matrix_multiply,
+    transpose,
     matrix_vector_multiply,
     student_t_two_tailed_pvalue,
     symmetric_eigendecomposition,
@@ -139,3 +143,217 @@ class AssociationAnalyzer:
                 }
             )
         return results
+
+
+@dataclass
+class DendrogramNode:
+    """Node describing a hierarchical clustering result."""
+
+    name: str
+    distance: float = 0.0
+    left: Optional["DendrogramNode"] = None
+    right: Optional["DendrogramNode"] = None
+
+    def is_leaf(self) -> bool:
+        return self.left is None and self.right is None
+
+    def members(self) -> List[str]:
+        if self.is_leaf():
+            return [self.name]
+        members: List[str] = []
+        if self.left is not None:
+            members.extend(self.left.members())
+        if self.right is not None:
+            members.extend(self.right.members())
+        return members
+
+
+@dataclass
+class DendrogramAnalyzer:
+    """Perform simple agglomerative clustering on genotype data."""
+
+    linkage: str = "average"
+    root_: Optional[DendrogramNode] = field(init=False, default=None)
+    merges_: List[Tuple[List[str], List[str], float]] = field(init=False, default_factory=list)
+
+    def fit(self, dataset: GenotypeDataset) -> "DendrogramAnalyzer":
+        matrix, _, _ = dataset.standardized_matrix(impute=True)
+        n = len(dataset.individuals)
+        if n == 0:
+            raise ValueError("Dataset must contain at least one individual")
+
+        clusters: Dict[int, DendrogramNode] = {
+            i: DendrogramNode(name=dataset.individuals[i]) for i in range(n)
+        }
+        sizes: Dict[int, int] = {i: 1 for i in range(n)}
+        distances: Dict[int, Dict[int, float]] = {i: {} for i in range(n)}
+
+        def _euclidean(a: Sequence[float], b: Sequence[float]) -> float:
+            return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                dist = _euclidean(matrix[i], matrix[j])
+                distances[i][j] = dist
+                distances[j][i] = dist
+
+        active_ids = list(clusters.keys())
+        next_id = n
+        self.merges_.clear()
+
+        while len(active_ids) > 1:
+            min_dist = float("inf")
+            pair: Tuple[int, int] | None = None
+            for i in active_ids:
+                for j in active_ids:
+                    if i >= j:
+                        continue
+                    dist = distances[i].get(j)
+                    if dist is None:
+                        continue
+                    if dist < min_dist:
+                        min_dist = dist
+                        pair = (i, j)
+            if pair is None:
+                break
+            i, j = pair
+            left = clusters[i]
+            right = clusters[j]
+            new_node = DendrogramNode(
+                name=f"cluster_{next_id}",
+                distance=min_dist,
+                left=left,
+                right=right,
+            )
+            clusters[next_id] = new_node
+            sizes[next_id] = sizes[i] + sizes[j]
+            self.merges_.append((left.members(), right.members(), min_dist))
+
+            for other in active_ids:
+                if other in (i, j):
+                    continue
+                dist_i = distances[i].get(other, 0.0)
+                dist_j = distances[j].get(other, 0.0)
+                if self.linkage == "single":
+                    new_dist = min(dist_i, dist_j)
+                elif self.linkage == "complete":
+                    new_dist = max(dist_i, dist_j)
+                else:  # average linkage
+                    new_dist = (
+                        dist_i * sizes[i] + dist_j * sizes[j]
+                    ) / (sizes[i] + sizes[j])
+                distances.setdefault(other, {})[next_id] = new_dist
+                distances.setdefault(next_id, {})[other] = new_dist
+
+            for key in (i, j):
+                active_ids.remove(key)
+                distances.pop(key, None)
+                sizes.pop(key, None)
+                for dist_map in distances.values():
+                    dist_map.pop(key, None)
+                clusters.pop(key, None)
+
+            active_ids.append(next_id)
+            next_id += 1
+
+        if not clusters:
+            raise RuntimeError("Clustering failed to produce any nodes")
+        self.root_ = clusters[active_ids[0]]
+        return self
+
+    def get_root(self) -> DendrogramNode:
+        if self.root_ is None:
+            raise RuntimeError("Analyzer has not been fitted")
+        return self.root_
+
+
+@dataclass
+class AdmixtureAnalyzer:
+    """Estimate ancestry proportions using a basic NMF approach."""
+
+    n_populations: int
+    max_iter: int = 500
+    tol: float = 1e-4
+    random_state: Optional[int] = None
+    q_matrix_: List[List[float]] = field(init=False, default_factory=list)
+    allele_frequencies_: List[List[float]] = field(init=False, default_factory=list)
+
+    def fit(self, dataset: GenotypeDataset) -> "AdmixtureAnalyzer":
+        if self.n_populations < 1:
+            raise ValueError("n_populations must be at least 1")
+        matrix = dataset.to_matrix(impute=True)
+        if not matrix:
+            raise ValueError("Genotype matrix is empty")
+        n_individuals = len(matrix)
+        n_markers = len(matrix[0])
+        rng = random.Random(self.random_state)
+
+        q = [[rng.random() + 1e-3 for _ in range(self.n_populations)] for _ in range(n_individuals)]
+        h = [[rng.random() + 1e-3 for _ in range(n_markers)] for _ in range(self.n_populations)]
+
+        def _normalize_rows(mat: List[List[float]]) -> None:
+            for row in mat:
+                total = sum(row)
+                if total <= 0:
+                    continue
+                for idx in range(len(row)):
+                    row[idx] = row[idx] / total
+
+        _normalize_rows(q)
+
+        last_error = float("inf")
+        for _ in range(self.max_iter):
+            # Update allele frequencies (H matrix)
+            q_t = transpose(q)
+            numerator_h = matrix_multiply(q_t, matrix)
+            qtq = matrix_multiply(q_t, q)
+            denominator_h = matrix_multiply(qtq, h)
+            for k in range(self.n_populations):
+                for j in range(n_markers):
+                    denom = denominator_h[k][j] if denominator_h[k][j] > 1e-9 else 1e-9
+                    h[k][j] = max(1e-9, h[k][j] * numerator_h[k][j] / denom)
+
+            # Update q matrix (W matrix)
+            h_t = transpose(h)
+            numerator_q = matrix_multiply(matrix, h_t)
+            hh_t = matrix_multiply(h, h_t)
+            denominator_q = matrix_multiply(q, hh_t)
+            for i in range(n_individuals):
+                for k in range(self.n_populations):
+                    denom = denominator_q[i][k] if denominator_q[i][k] > 1e-9 else 1e-9
+                    q[i][k] = max(1e-9, q[i][k] * numerator_q[i][k] / denom)
+
+            _normalize_rows(q)
+
+            reconstruction = matrix_multiply(q, h)
+            error = 0.0
+            for i in range(n_individuals):
+                for j in range(n_markers):
+                    diff = matrix[i][j] - reconstruction[i][j]
+                    error += diff * diff
+            if abs(last_error - error) < self.tol:
+                break
+            last_error = error
+
+        self.q_matrix_ = q
+        self.allele_frequencies_ = h
+        return self
+
+    def transform(self, dataset: GenotypeDataset) -> List[List[float]]:
+        if not self.q_matrix_:
+            raise RuntimeError("AdmixtureAnalyzer must be fitted before transform().")
+        # For simplicity, recompute memberships using fitted allele frequencies.
+        matrix = dataset.to_matrix(impute=True)
+        h_t = transpose(self.allele_frequencies_)
+        hh_t = matrix_multiply(self.allele_frequencies_, h_t)
+        q = [[1.0 for _ in range(self.n_populations)] for _ in matrix]
+        numerator_q = matrix_multiply(matrix, h_t)
+        denominator_q = matrix_multiply(q, hh_t)
+        for i in range(len(matrix)):
+            for k in range(self.n_populations):
+                denom = denominator_q[i][k] if denominator_q[i][k] > 1e-9 else 1e-9
+                q[i][k] = max(1e-9, q[i][k] * numerator_q[i][k] / denom)
+            total = sum(q[i])
+            if total > 0:
+                q[i] = [value / total for value in q[i]]
+        return q

--- a/breeder/plotting.py
+++ b/breeder/plotting.py
@@ -1,0 +1,235 @@
+"""Interactive plotting utilities based on Plotly without runtime dependency."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .analysis import DendrogramNode
+
+PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.27.0.min.js"
+
+
+def _write_plotly_html(fig: dict, output: str | Path) -> None:
+    target = Path(output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    figure_json = json.dumps(fig)
+    html = f"""
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"utf-8\" />
+    <script src=\"{PLOTLY_CDN}\"></script>
+    <title>Interactive plot</title>
+    <style>
+        html, body {{ height: 100%; margin: 0; }}
+        #plot {{ width: 100%; height: 100%; }}
+    </style>
+</head>
+<body>
+    <div id=\"plot\"></div>
+    <script>
+        const figure = {figure_json};
+        Plotly.newPlot('plot', figure.data, figure.layout, {{responsive: true}});
+    </script>
+</body>
+</html>
+"""
+    target.write_text(html, encoding="utf-8")
+
+
+def pca_scatter(scores: Sequence[Sequence[float]], individuals: Sequence[str], explained: Sequence[float], output: str | Path) -> None:
+    if not scores:
+        raise ValueError("scores must contain at least one entry")
+    x = [row[0] for row in scores]
+    y = [row[1] if len(row) > 1 else 0.0 for row in scores]
+    hover = [f"{ind}<br>PC1: {row[0]:.3f}<br>PC2: {row[1]:.3f}" for ind, row in zip(individuals, scores)]
+    var1 = explained[0] * 100 if explained else 0.0
+    var2 = explained[1] * 100 if len(explained) > 1 else 0.0
+    fig = {
+        "data": [
+            {
+                "type": "scatter",
+                "mode": "markers",
+                "x": x,
+                "y": y,
+                "text": hover,
+                "hovertemplate": "%{text}<extra></extra>",
+            }
+        ],
+        "layout": {
+            "title": "PCA Scatter",
+            "xaxis": {"title": f"PC1 ({var1:.2f}% var)"},
+            "yaxis": {"title": f"PC2 ({var2:.2f}% var)"},
+            "template": "plotly_white",
+        },
+    }
+    _write_plotly_html(fig, output)
+
+
+def gwas_manhattan(results: Sequence[dict], output: str | Path) -> None:
+    if not results:
+        raise ValueError("results must not be empty")
+    positions = list(range(len(results)))
+    neg_log_p = [_neg_log10(entry.get("pvalue", 1.0)) for entry in results]
+    markers = [entry.get("marker", f"M{i}") for i, entry in enumerate(results)]
+    fig = {
+        "data": [
+            {
+                "type": "scatter",
+                "mode": "markers",
+                "x": positions,
+                "y": neg_log_p,
+                "text": markers,
+                "hovertemplate": "Marker: %{text}<br>-log10(p): %{y:.3f}<extra></extra>",
+            }
+        ],
+        "layout": {
+            "title": "GWAS Manhattan Plot",
+            "xaxis": {"title": "Variant Index"},
+            "yaxis": {"title": "-log10(pvalue)"},
+            "template": "plotly_white",
+        },
+    }
+    _write_plotly_html(fig, output)
+
+
+def _assign_leaf_positions(node: DendrogramNode, order: List[str], positions: dict) -> None:
+    if node.is_leaf():
+        positions[node.name] = len(order)
+        order.append(node.name)
+        return
+    if node.left is not None:
+        _assign_leaf_positions(node.left, order, positions)
+    if node.right is not None:
+        _assign_leaf_positions(node.right, order, positions)
+def dendrogram_plot(root: DendrogramNode, output: str | Path) -> None:
+    order: List[str] = []
+    positions: dict = {}
+    _assign_leaf_positions(root, order, positions)
+    leaves = order
+    if not leaves:
+        raise ValueError("Dendrogram must contain at least one leaf")
+    max_distance = max((node.distance for node in _iter_nodes(root)), default=0.0)
+    if max_distance == 0:
+        max_distance = 1.0
+
+    x_coords: List[float] = []
+    y_coords: List[float] = []
+    for name in leaves:
+        x_coords.append(positions[name])
+        y_coords.append(0.0)
+
+    lines_x: List[List[float]] = []
+    lines_y: List[List[float]] = []
+
+    def _traverse(node: DendrogramNode) -> None:
+        if node.is_leaf():
+            return
+        if node.left is not None:
+            _traverse(node.left)
+        if node.right is not None:
+            _traverse(node.right)
+        if node.left is None or node.right is None:
+            return
+        left_names = node.left.members()
+        right_names = node.right.members()
+        left_x = [positions[name] for name in left_names]
+        right_x = [positions[name] for name in right_names]
+        left_y = node.left.distance
+        right_y = node.right.distance
+        current_y = node.distance
+        lines_x.append([min(left_x), max(left_x)])
+        lines_y.append([left_y, left_y])
+        lines_x.append([min(right_x), max(right_x)])
+        lines_y.append([right_y, right_y])
+        lines_x.append([sum(left_x) / len(left_x), sum(right_x) / len(right_x)])
+        lines_y.append([current_y, current_y])
+        lines_x.append([sum(left_x) / len(left_x), sum(left_x) / len(left_x)])
+        lines_y.append([left_y, current_y])
+        lines_x.append([sum(right_x) / len(right_x), sum(right_x) / len(right_x)])
+        lines_y.append([right_y, current_y])
+
+    _traverse(root)
+
+    traces = [
+        {
+            "type": "scatter",
+            "mode": "markers",
+            "x": x_coords,
+            "y": y_coords,
+            "text": leaves,
+            "hovertemplate": "%{text}<extra></extra>",
+        }
+    ]
+
+    for x_vals, y_vals in zip(lines_x, lines_y):
+        traces.append(
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "x": x_vals,
+                "y": y_vals,
+                "line": {"color": "#636efa"},
+                "hoverinfo": "skip",
+            }
+        )
+
+    fig = {
+        "data": traces,
+        "layout": {
+            "title": "Dendrogram",
+            "xaxis": {"tickvals": list(range(len(leaves))), "ticktext": leaves, "tickangle": 45},
+            "yaxis": {"title": "Distance", "range": [0, max_distance * 1.05]},
+            "template": "plotly_white",
+        },
+    }
+    _write_plotly_html(fig, output)
+
+
+def _iter_nodes(node: DendrogramNode) -> Iterable[DendrogramNode]:
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        if current.left is not None:
+            stack.append(current.left)
+        if current.right is not None:
+            stack.append(current.right)
+
+
+def admixture_plot(q_matrix: Sequence[Sequence[float]], individuals: Sequence[str], output: str | Path) -> None:
+    if not q_matrix:
+        raise ValueError("q_matrix must not be empty")
+    n_components = len(q_matrix[0])
+    if n_components == 0:
+        raise ValueError("q_matrix must contain at least one component")
+    traces = []
+    for comp in range(n_components):
+        values = [row[comp] for row in q_matrix]
+        traces.append(
+            {
+                "type": "bar",
+                "x": individuals,
+                "y": values,
+                "name": f"Cluster {comp + 1}",
+            }
+        )
+    layout = {
+        "barmode": "stack",
+        "title": "Admixture Proportions",
+        "xaxis": {"title": "Individuals", "tickangle": 45},
+        "yaxis": {"title": "Proportion", "range": [0, 1]},
+        "template": "plotly_white",
+    }
+    fig = {"data": traces, "layout": layout}
+    _write_plotly_html(fig, output)
+
+
+def _neg_log10(value: float) -> float:
+    if value <= 0:
+        return 0.0
+    import math
+
+    return -math.log10(value)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from breeder.analysis import DendrogramAnalyzer
+from breeder.data import GenotypeDataset
+from breeder.plotting import admixture_plot, dendrogram_plot, gwas_manhattan, pca_scatter
+
+
+@pytest.fixture
+def genotype_dataset() -> GenotypeDataset:
+    return GenotypeDataset.from_csv("tests/data/genotype.csv", index_col="id")
+
+
+def test_pca_scatter_creates_html(tmp_path: Path, genotype_dataset: GenotypeDataset) -> None:
+    from breeder.analysis import PopulationStructureAnalyzer
+
+    analyzer = PopulationStructureAnalyzer(n_components=2)
+    analyzer.fit(genotype_dataset)
+    scores = analyzer.transform(genotype_dataset)
+    target = tmp_path / "pca.html"
+    pca_scatter(scores, genotype_dataset.individuals, analyzer.explained_variance_ratio, target)
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "Plotly.newPlot" in content
+
+
+def test_gwas_manhattan_creates_html(tmp_path: Path) -> None:
+    results = [
+        {"marker": "M1", "pvalue": 0.05},
+        {"marker": "M2", "pvalue": 1e-4},
+        {"marker": "M3", "pvalue": 0.5},
+    ]
+    target = tmp_path / "gwas.html"
+    gwas_manhattan(results, target)
+    assert target.exists()
+    assert "Plotly.newPlot" in target.read_text(encoding="utf-8")
+
+
+def test_dendrogram_plot_creates_html(tmp_path: Path, genotype_dataset: GenotypeDataset) -> None:
+    analyzer = DendrogramAnalyzer()
+    analyzer.fit(genotype_dataset)
+    target = tmp_path / "dendrogram.html"
+    dendrogram_plot(analyzer.get_root(), target)
+    assert target.exists()
+
+
+def test_admixture_plot_creates_html(tmp_path: Path, genotype_dataset: GenotypeDataset) -> None:
+    from breeder.analysis import AdmixtureAnalyzer
+
+    analyzer = AdmixtureAnalyzer(n_populations=2, max_iter=10, random_state=0)
+    analyzer.fit(genotype_dataset)
+    target = tmp_path / "admixture.html"
+    admixture_plot(analyzer.q_matrix_, genotype_dataset.individuals, target)
+    assert target.exists()


### PR DESCRIPTION
## Summary
- implement dendrogram clustering and admixture estimation analyzers with supporting CLI commands and HTML outputs
- add reusable Plotly-based utilities and wire PCA and GWAS commands to emit interactive plots when requested
- document the new workflows and cover them with tests for the analyses and interactive report generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4bf8675b0832ea5afbce3ca0266a1